### PR TITLE
Update triggers

### DIFF
--- a/workflow-templates/dotnetdev.yaml
+++ b/workflow-templates/dotnetdev.yaml
@@ -1,10 +1,7 @@
 name: x Dev Build Release Pipeline  # Replace x with App name
 run-name: x dev build/release by @${{ github.actor }} # Replace x with App name
 on:
-  push:
-    branches:
-      - '*'
-      - '!main'
+  workflow_dispatch:
 env:
   appName: # Add App name abbreviation here, e.g. iacm, pcap
   appRegion: # uksouth or eastus2

--- a/workflow-templates/dotnettest.yaml
+++ b/workflow-templates/dotnettest.yaml
@@ -1,10 +1,7 @@
 name: x Test Build Release Pipeline  # Replace x with App name
 run-name: x test build/release by @${{ github.actor }} # Replace x with App name
 on:
-  push:
-    branches:
-      - '*'
-      - '!main'
+  workflow_dispatch:
 env:
   appName: # Add App name abbreviation here, e.g. iacm, pcap
   appRegion: # uksouth or eastus2


### PR DESCRIPTION
The Application Development team have requested that their pipelines not trigger automatically, and only run when manually queued. This PR replaces the trigger in the workflow templates to 'workflow dispatch' to ensure this.

###Testing

It's not possible to test these by running them, as they are just templates and there's no code to deploy; they can't be tested in other repos because the templates can't be pulled until they're in main. However these will be used to build a number of test pipelines for AD team this week, so any issues will be corrected.