### PR TITLE
Add fixes to templates

### DIFF
--- a/workflow-templates/dotnetdev-func.yaml
+++ b/workflow-templates/dotnetdev-func.yaml
@@ -7,7 +7,7 @@ env:
   appRegion: # uksouth or eastus2
 jobs:
   build_release:
-    runs-on: Adv-Gher-Lin2
+    runs-on: adv-linux-eastus2
     env:
       workingDirectory: # Add name of directory with code here
     steps:
@@ -30,7 +30,9 @@ jobs:
       run: dotnet build --output publish_output --configuration Release
     - name: Zip build artifact
       working-directory: ${{ env.workingDirectory }}
-      run: zip -r ${{ github.run_id }}.zip publish_output
+      run: |
+        cd publish_output
+        zip -r ${{ github.run_id }}.zip .
     - name: Release project
       working-directory: ${{ env.workingDirectory }}
-      run: az functionapp deployment source config-zip -g rg-${{ env.appName }}-${{ env.appRegion }}-dev -n func-${{ env.appName }}-${{ env.appRegion }}-dev-1 --src ${{ github.run_id }}.zip
+      run: az functionapp deployment source config-zip -g rg-${{ env.appName }}-${{ env.appRegion }}-dev -n func-${{ env.appName }}-${{ env.appRegion }}-dev-1 --src publish_output/${{ github.run_id }}.zip

--- a/workflow-templates/dotnetdev-web.yaml
+++ b/workflow-templates/dotnetdev-web.yaml
@@ -30,9 +30,7 @@ jobs:
       run: dotnet build --output publish_output --configuration Release
     - name: Zip build artifact
       working-directory: ${{ env.workingDirectory }}
-      run: |
-        cd publish_output
-        zip -r ${{ github.run_id }}.zip .
+      run: zip -r ${{ github.run_id }}.zip publish_output
     - name: Release project
       working-directory: ${{ env.workingDirectory }}
-      run: az webapp deployment source config-zip -g rg-${{ env.appName }}-${{ env.appRegion }}-dev -n app-${{ env.appName }}-${{ env.appRegion }}-dev-1 --src publish_output/${{ github.run_id }}.zip
+      run: az webapp deployment source config-zip -g rg-${{ env.appName }}-${{ env.appRegion }}-dev -n app-${{ env.appName }}-${{ env.appRegion }}-dev-1 --src ${{ github.run_id }}.zip

--- a/workflow-templates/dotnetdev-web.yaml
+++ b/workflow-templates/dotnetdev-web.yaml
@@ -7,7 +7,7 @@ env:
   appRegion: # uksouth or eastus2
 jobs:
   build_release:
-    runs-on: Adv-Gher-Lin2
+    runs-on: adv-linux-eastus2
     env:
       workingDirectory: # Add name of directory with code here
     steps:
@@ -30,7 +30,9 @@ jobs:
       run: dotnet build --output publish_output --configuration Release
     - name: Zip build artifact
       working-directory: ${{ env.workingDirectory }}
-      run: zip -r ${{ github.run_id }}.zip publish_output
+      run: |
+        cd publish_output
+        zip -r ${{ github.run_id }}.zip .
     - name: Release project
       working-directory: ${{ env.workingDirectory }}
-      run: az webapp deployment source config-zip -g rg-${{ env.appName }}-${{ env.appRegion }}-dev -n app-${{ env.appName }}-${{ env.appRegion }}-dev-1 --src ${{ github.run_id }}.zip
+      run: az webapp deployment source config-zip -g rg-${{ env.appName }}-${{ env.appRegion }}-dev -n app-${{ env.appName }}-${{ env.appRegion }}-dev-1 --src publish_output/${{ github.run_id }}.zip

--- a/workflow-templates/dotnetprod-func.yaml
+++ b/workflow-templates/dotnetprod-func.yaml
@@ -7,7 +7,7 @@ env:
   appRegion: # uksouth or eastus2
 jobs:
   build_release:
-    runs-on: Adv-Gher-Lin2
+    runs-on: adv-linux-eastus2
     env:
       workingDirectory: # Add name of directory with code here
     steps:
@@ -30,7 +30,9 @@ jobs:
       run: dotnet build --output publish_output --configuration Release
     - name: Zip build artifact
       working-directory: ${{ env.workingDirectory }}
-      run: zip -r ${{ github.run_id }}.zip publish_output
+      run: |
+        cd publish_output
+        zip -r ${{ github.run_id }}.zip .
     - name: Release project
       working-directory: ${{ env.workingDirectory }}
-      run: az functionapp deployment source config-zip -g rg-${{ env.appName }}-${{ env.appRegion }}-prod -n func-${{ env.appName }}-${{ env.appRegion }}-prod-1 --src ${{ github.run_id }}.zip
+      run: az functionapp deployment source config-zip -g rg-${{ env.appName }}-${{ env.appRegion }}-prod -n func-${{ env.appName }}-${{ env.appRegion }}-prod-1 --src publish_output/${{ github.run_id }}.zip

--- a/workflow-templates/dotnetprod-web.yaml
+++ b/workflow-templates/dotnetprod-web.yaml
@@ -30,9 +30,7 @@ jobs:
       run: dotnet build --output publish_output --configuration Release
     - name: Zip build artifact
       working-directory: ${{ env.workingDirectory }}
-      run: |
-        cd publish_output
-        zip -r ${{ github.run_id }}.zip .
+      run: zip -r ${{ github.run_id }}.zip publish_output
     - name: Release project
       working-directory: ${{ env.workingDirectory }}
-      run: az webapp deployment source config-zip -g rg-${{ env.appName }}-${{ env.appRegion }}-prod -n app-${{ env.appName }}-${{ env.appRegion }}-prod-1 --src publish_output/${{ github.run_id }}.zip
+      run: az webapp deployment source config-zip -g rg-${{ env.appName }}-${{ env.appRegion }}-prod -n app-${{ env.appName }}-${{ env.appRegion }}-prod-1 --src ${{ github.run_id }}.zip

--- a/workflow-templates/dotnetprod-web.yaml
+++ b/workflow-templates/dotnetprod-web.yaml
@@ -7,7 +7,7 @@ env:
   appRegion: # uksouth or eastus2
 jobs:
   build_release:
-    runs-on: Adv-Gher-Lin2
+    runs-on: adv-linux-eastus2
     env:
       workingDirectory: # Add name of directory with code here
     steps:
@@ -30,7 +30,9 @@ jobs:
       run: dotnet build --output publish_output --configuration Release
     - name: Zip build artifact
       working-directory: ${{ env.workingDirectory }}
-      run: zip -r ${{ github.run_id }}.zip publish_output
+      run: |
+        cd publish_output
+        zip -r ${{ github.run_id }}.zip .
     - name: Release project
       working-directory: ${{ env.workingDirectory }}
-      run: az webapp deployment source config-zip -g rg-${{ env.appName }}-${{ env.appRegion }}-prod -n app-${{ env.appName }}-${{ env.appRegion }}-prod-1 --src ${{ github.run_id }}.zip
+      run: az webapp deployment source config-zip -g rg-${{ env.appName }}-${{ env.appRegion }}-prod -n app-${{ env.appName }}-${{ env.appRegion }}-prod-1 --src publish_output/${{ github.run_id }}.zip

--- a/workflow-templates/dotnettest-func.yaml
+++ b/workflow-templates/dotnettest-func.yaml
@@ -7,7 +7,7 @@ env:
   appRegion: # uksouth or eastus2
 jobs:
   build_release:
-    runs-on: Adv-Gher-Lin2
+    runs-on: adv-linux-eastus2
     env:
       workingDirectory: # Add name of directory with code here
     steps:
@@ -30,7 +30,9 @@ jobs:
       run: dotnet build --output publish_output --configuration Release
     - name: Zip build artifact
       working-directory: ${{ env.workingDirectory }}
-      run: zip -r ${{ github.run_id }}.zip publish_output
+      run: |
+        cd publish_output
+        zip -r ${{ github.run_id }}.zip .
     - name: Release project
       working-directory: ${{ env.workingDirectory }}
-      run: az functionapp deployment source config-zip -g rg-${{ env.appName }}-${{ env.appRegion }}-test -n func-${{ env.appName }}-${{ env.appRegion }}-test-1 --src ${{ github.run_id }}.zip
+      run: az functionapp deployment source config-zip -g rg-${{ env.appName }}-${{ env.appRegion }}-test -n func-${{ env.appName }}-${{ env.appRegion }}-test-1 --src publish_output/${{ github.run_id }}.zip

--- a/workflow-templates/dotnettest-web.yaml
+++ b/workflow-templates/dotnettest-web.yaml
@@ -30,9 +30,7 @@ jobs:
       run: dotnet build --output publish_output --configuration Release
     - name: Zip build artifact
       working-directory: ${{ env.workingDirectory }}
-      run: |
-        cd publish_output
-        zip -r ${{ github.run_id }}.zip .
+      run: zip -r ${{ github.run_id }}.zip publish_output
     - name: Release project
       working-directory: ${{ env.workingDirectory }}
-      run: az webapp deployment source config-zip -g rg-${{ env.appName }}-${{ env.appRegion }}-test -n app-${{ env.appName }}-${{ env.appRegion }}-test-1 --src publish_output/${{ github.run_id }}.zip
+      run: az webapp deployment source config-zip -g rg-${{ env.appName }}-${{ env.appRegion }}-test -n app-${{ env.appName }}-${{ env.appRegion }}-test-1 --src ${{ github.run_id }}.zip

--- a/workflow-templates/dotnettest-web.yaml
+++ b/workflow-templates/dotnettest-web.yaml
@@ -7,7 +7,7 @@ env:
   appRegion: # uksouth or eastus2
 jobs:
   build_release:
-    runs-on: Adv-Gher-Lin2
+    runs-on: adv-linux-eastus2
     env:
       workingDirectory: # Add name of directory with code here
     steps:
@@ -30,7 +30,9 @@ jobs:
       run: dotnet build --output publish_output --configuration Release
     - name: Zip build artifact
       working-directory: ${{ env.workingDirectory }}
-      run: zip -r ${{ github.run_id }}.zip publish_output
+      run: |
+        cd publish_output
+        zip -r ${{ github.run_id }}.zip .
     - name: Release project
       working-directory: ${{ env.workingDirectory }}
-      run: az webapp deployment source config-zip -g rg-${{ env.appName }}-${{ env.appRegion }}-test -n app-${{ env.appName }}-${{ env.appRegion }}-test-1 --src ${{ github.run_id }}.zip
+      run: az webapp deployment source config-zip -g rg-${{ env.appName }}-${{ env.appRegion }}-test -n app-${{ env.appName }}-${{ env.appRegion }}-test-1 --src publish_output/${{ github.run_id }}.zip


### PR DESCRIPTION
This implements fixes from testing in to the templates.

- runner pool name was wrong
- zip file was including the publish_output dir thus breaking the apps, so cd in to publish_output before making zip, then update source path to reflect the zip is now in publish_output dir, not root