### PR TITLE
update web app dotnet workflows with build and publish fixes

### DIFF
--- a/workflow-templates/dotnetdev-web.yaml
+++ b/workflow-templates/dotnetdev-web.yaml
@@ -27,10 +27,12 @@ jobs:
 #        config-file: # optional
     - name: Build project
       working-directory: ${{ env.workingDirectory }}
-      run: dotnet build --output publish_output --configuration Release
+      run: dotnet publish --output publish_output --configuration Release
     - name: Zip build artifact
       working-directory: ${{ env.workingDirectory }}
-      run: zip -r ${{ github.run_id }}.zip publish_output
+      run: |
+        cd publish_output
+        zip -r ${{ github.run_id }}.zip .
     - name: Release project
       working-directory: ${{ env.workingDirectory }}
-      run: az webapp deployment source config-zip -g rg-${{ env.appName }}-${{ env.appRegion }}-dev -n app-${{ env.appName }}-${{ env.appRegion }}-dev-1 --src ${{ github.run_id }}.zip
+      run: az webapp deployment source config-zip -g rg-${{ env.appName }}-${{ env.appRegion }}-dev -n app-${{ env.appName }}-${{ env.appRegion }}-dev-1 --src publish_output/${{ github.run_id }}.zip

--- a/workflow-templates/dotnetprod-web.yaml
+++ b/workflow-templates/dotnetprod-web.yaml
@@ -27,10 +27,12 @@ jobs:
 #        config-file: # optional
     - name: Build project
       working-directory: ${{ env.workingDirectory }}
-      run: dotnet build --output publish_output --configuration Release
+      run: dotnet publish --output publish_output --configuration Release
     - name: Zip build artifact
       working-directory: ${{ env.workingDirectory }}
-      run: zip -r ${{ github.run_id }}.zip publish_output
+      run: |
+        cd publish_output
+        zip -r ${{ github.run_id }}.zip .
     - name: Release project
       working-directory: ${{ env.workingDirectory }}
-      run: az webapp deployment source config-zip -g rg-${{ env.appName }}-${{ env.appRegion }}-prod -n app-${{ env.appName }}-${{ env.appRegion }}-prod-1 --src ${{ github.run_id }}.zip
+      run: az webapp deployment source config-zip -g rg-${{ env.appName }}-${{ env.appRegion }}-prod -n app-${{ env.appName }}-${{ env.appRegion }}-prod-1 --src publish_output/${{ github.run_id }}.zip

--- a/workflow-templates/dotnettest-web.yaml
+++ b/workflow-templates/dotnettest-web.yaml
@@ -27,10 +27,12 @@ jobs:
 #        config-file: # optional
     - name: Build project
       working-directory: ${{ env.workingDirectory }}
-      run: dotnet build --output publish_output --configuration Release
+      run: dotnet publish --output publish_output --configuration Release
     - name: Zip build artifact
       working-directory: ${{ env.workingDirectory }}
-      run: zip -r ${{ github.run_id }}.zip publish_output
+      run: |
+        cd publish_output
+        zip -r ${{ github.run_id }}.zip .
     - name: Release project
       working-directory: ${{ env.workingDirectory }}
-      run: az webapp deployment source config-zip -g rg-${{ env.appName }}-${{ env.appRegion }}-test -n app-${{ env.appName }}-${{ env.appRegion }}-test-1 --src ${{ github.run_id }}.zip
+      run: az webapp deployment source config-zip -g rg-${{ env.appName }}-${{ env.appRegion }}-test -n app-${{ env.appName }}-${{ env.appRegion }}-test-1 --src publish_output/${{ github.run_id }}.zip


### PR DESCRIPTION
This PR updates the dotnet web app workflows with fixes required due to issues found during a deployment to the [expertnetwork-web](https://github.com/Advent-International/expertnetwork-web) dev web app.  

`dotnet build` needed to be updated to `dotnet publish` so that other necessary files, such as the web.config file, were built. Additionally the publish directory is modified so that content is placed at the root `/home/site/wwwroot` and not under `/home/site/wwwroot/publish_output`.

Successful expertnetworks-web dev workflow test: https://github.com/Advent-International/expertnetwork-web/actions/runs/12675560790

Once these fixes were in place a new build was run to publish content to the expertnetwork-web dev web app which restored access to the site:
![image](https://github.com/user-attachments/assets/888c692b-1b99-4635-9d94-7fe5c584ad9f)
