### PR TITLE
Fix Dev Resource Group Name Reference

### DIFF
--- a/workflow-templates/pythondev-func.yaml
+++ b/workflow-templates/pythondev-func.yaml
@@ -150,7 +150,7 @@ jobs:
         working-directory: ${{ env.workingDirectory }}
         run: |
           az functionapp deployment source config-zip \
-            -g rg-${{ env.appName }}-${{ env.appRegion }} \
+            -g rg-${{ env.appName }}-${{ env.appRegion }}-dev \
             -n func-${{ env.appName }}-${{ env.appRegion }}-dev-1 \
             --src ${{ github.run_id }}.zip
 


### PR DESCRIPTION
This pull request makes a minor update to the deployment process for Azure Function Apps in the `workflow-templates/pythondev-func.yaml` file. The change ensures that the resource group name used during deployment includes the `-dev` suffix, aligning it with the naming convention for development environments.

* Updated the `az functionapp deployment source config-zip` command to use the resource group name with a `-dev` suffix, ensuring consistency with other development resources.